### PR TITLE
Adds a testbench

### DIFF
--- a/package.js
+++ b/package.js
@@ -14,6 +14,10 @@ content.dependencies = {
   'keycode': '^2.0.0'
 }
 content.devDependencies = {
+  sinon: '^1.14.1',
+  jquery: '^1.11.2',
+  express: '^4.12.3',
+  'browserify-middleware': '^5.0.2',
   mightyiam: '^1.1.5',
   policystat: '^1.2.2',
   'auto-package': '^0.2.0',
@@ -42,6 +46,7 @@ content.scripts = {
     ' -n "' + policystat.name.pretty + '"',
   'docs': 'verb',
   'lint': 'standard',
+  'start-testbench-server': 'node test/bench/server',
   'test-browsers': 'karma start',
   'test': 'npm run license && npm run docs && npm run lint && npm run test-browsers'
 }

--- a/test/bench/client/create-editables-table-structure.js
+++ b/test/bench/client/create-editables-table-structure.js
@@ -1,0 +1,14 @@
+module.exports = function ($editablesTable, tag) {
+  $editablesTable.find('tbody').append([
+    '<tr class="' + tag + '">',
+      '<td class="tag">' + tag + '</td>',
+      '<td class="element"></td>',
+      '<td class="callback-count">',
+        '<ul style="list-style-type: none">',
+          '<li>onSensible: <span class="report on-sensible"></span></li>',
+          '<li>onAny: <span class="report on-any"></span></li>',
+        '</ul>',
+      '</td>',
+    '</tr>'
+  ].join(''))
+}

--- a/test/bench/client/editable-tags.js
+++ b/test/bench/client/editable-tags.js
@@ -1,0 +1,12 @@
+module.exports = [
+  'div',
+  'p',
+  'h3',
+  'pre',
+  'blockquote',
+  'textarea',
+  'input',
+  'span',
+  'a',
+  'button'
+]

--- a/test/bench/client/get-on-any-edit-callback.js
+++ b/test/bench/client/get-on-any-edit-callback.js
@@ -1,0 +1,7 @@
+var sinon = require('sinon') // for debugging
+
+module.exports = sinon.spy(function () {
+  var editedInstance = this
+
+  require('./increment-callback-counter')(editedInstance, 'on-any')
+})

--- a/test/bench/client/get-on-sensible-edit-callback.js
+++ b/test/bench/client/get-on-sensible-edit-callback.js
@@ -1,0 +1,7 @@
+var sinon = require('sinon') // for debugging
+
+module.exports = sinon.spy(function () {
+  var editedInstance = this
+
+  require('./increment-callback-counter')(editedInstance, 'on-sensible')
+})

--- a/test/bench/client/increment-callback-counter.js
+++ b/test/bench/client/increment-callback-counter.js
@@ -1,0 +1,9 @@
+var $ = require('jquery')
+
+module.exports = function (editedInstance, callbackType) {
+  var $row = $(editedInstance.element).parents('tr:first')
+
+  var $callbackCounter = $row.find('td.callback-count span.' + callbackType)
+  var currentCount = Number($callbackCounter.html())
+  $callbackCounter.html(currentCount + 1)
+}

--- a/test/bench/client/index.js
+++ b/test/bench/client/index.js
@@ -1,0 +1,10 @@
+require('es5-shim')
+var $ = require('jquery')
+var makeHeadingAndDescription = require('./make-heading-and-description')
+var makeEditablesTable = require('./make-editables-table')
+
+document.title = 'edited Test Bench'
+makeHeadingAndDescription()
+
+$('body').append('<h2>Editable Elements</h2>')
+makeEditablesTable()

--- a/test/bench/client/instantiate-edited-on-editable-element.js
+++ b/test/bench/client/instantiate-edited-on-editable-element.js
@@ -1,0 +1,12 @@
+var Edited = require('../../..')
+var onSensibleEditCallback = require('./get-on-sensible-edit-callback')
+var onAnyEditCallback = require('./get-on-any-edit-callback')
+
+module.exports = function ($editablesTable, tag) {
+  var editableElement = $editablesTable.find(
+    'tr.' + tag + ' td.element .editable-element'
+  ).get(0)
+  /* eslint-disable no-new */
+  new Edited(editableElement, onSensibleEditCallback, onAnyEditCallback)
+  /* eslint-enable no-new */
+}

--- a/test/bench/client/make-editable-element-editable.js
+++ b/test/bench/client/make-editable-element-editable.js
@@ -1,0 +1,5 @@
+module.exports = function ($editableElement) {
+  if (!$editableElement.is('textarea')) {
+    $editableElement.attr('contentEditable', true)
+  }
+}

--- a/test/bench/client/make-editable-element-in-editables-table.js
+++ b/test/bench/client/make-editable-element-in-editables-table.js
@@ -1,0 +1,11 @@
+var $ = require('jquery')
+var stylizeEditableElement = require('./stylize-editable-element')
+var makeEditableElementEditable = require('./make-editable-element-editable')
+
+module.exports = function ($editablesTable, tag) {
+  var $editableElement = $('<' + tag + ' class="editable-element">')
+  $editablesTable.find('tr.' + tag + ' td.element')
+    .append($editableElement)
+  stylizeEditableElement($editableElement)
+  makeEditableElementEditable($editableElement)
+}

--- a/test/bench/client/make-editables-table.js
+++ b/test/bench/client/make-editables-table.js
@@ -1,0 +1,14 @@
+var $ = require('jquery')
+var populateEditablesTable = require('./populate-editables-table')
+
+module.exports = function () {
+  var $editablesTable = $([
+    '<table id="editables"><tbody>',
+      '<tr>',
+        '<th>Element Tag</th><th>Element (type in me!)</th><th>Callback Count</th>',
+      '</tr>',
+    '</tbody></table>'
+  ].join('')).appendTo('body')
+
+  populateEditablesTable($editablesTable)
+}

--- a/test/bench/client/make-heading-and-description.js
+++ b/test/bench/client/make-heading-and-description.js
@@ -1,0 +1,7 @@
+var $ = require('jquery')
+
+module.exports = function () {
+  var $body = $('body')
+  $body.append('<h1>Test Bench for <a href="https://github.com/PolicyStat/edited">edited</a></h1>')
+  $body.append('<p>This page is for manual and automatic browser functional testing.</p>')
+}

--- a/test/bench/client/populate-editables-table.js
+++ b/test/bench/client/populate-editables-table.js
@@ -1,0 +1,12 @@
+var createEditablesTableStructure = require('./create-editables-table-structure')
+var makeEditableElementInEditablesTable = require('./make-editable-element-in-editables-table')
+var instantiateEditedOnEditableElement = require('./instantiate-edited-on-editable-element')
+var editablesTags = require('./editable-tags')
+
+module.exports = function ($editablesTable) {
+  editablesTags.forEach(function (tag) {
+    createEditablesTableStructure($editablesTable, tag)
+    makeEditableElementInEditablesTable($editablesTable, tag)
+    instantiateEditedOnEditableElement($editablesTable, tag)
+  })
+}

--- a/test/bench/client/stylize-editable-element.js
+++ b/test/bench/client/stylize-editable-element.js
@@ -1,0 +1,6 @@
+module.exports = function ($editableElement) {
+  $editableElement.css({
+    'min-height': '1em',
+    border: '2px dotted pink'
+  })
+}

--- a/test/bench/server/html.js
+++ b/test/bench/server/html.js
@@ -1,0 +1,8 @@
+module.exports = [
+  '<!DOCTYPE html>',
+  '<html>',
+    '<body>',
+      '<script src="index.js"></script>',
+    '</body>',
+  '</html>'
+].join('')

--- a/test/bench/server/index.js
+++ b/test/bench/server/index.js
@@ -1,0 +1,3 @@
+var startServer = require('./start-server')
+
+startServer()

--- a/test/bench/server/start-server.js
+++ b/test/bench/server/start-server.js
@@ -1,0 +1,10 @@
+var bench = require('express')()
+var browserify = require('browserify-middleware')
+
+module.exports = function () {
+  bench.get('/', function (req, res) {
+    res.send(require('./html'))
+  })
+  bench.get('/index.js', browserify('./test/bench/client/index.js'))
+  bench.listen(8888)
+}


### PR DESCRIPTION
Demos are better than words so checkout this branch and then

```sh
$ node package.js
$ npm install
$ npm run start-testbench-server
```

And open your browser at `http://localhost:8888` (I intend to replace this hard coded port with a [dynamically chosen one](https://www.npmjs.com/package/portfinder)).

Played with it a bit?

This is useful for manual debugging and testing and also for the future automated browser functional testing (I'm currently thinking [Nightwatch.js](http://nightwatchjs.org/)).

It can also be a basis for a pretty demo on a public site.